### PR TITLE
build: bump deps to bom 0.192.0

### DIFF
--- a/.github/workflows/clojure.yml
+++ b/.github/workflows/clojure.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install dependencies
       run: lein -U deps
     - name: Setup test config

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # clj-gcloud-common
 
+## [Unreleased]
+### Changed
+* Bumped dependencies - 0.192.0 bom
+
 ## [0.185-1.0] - 2023-01-24
 ### Changed
 * Bumped dependencies

--- a/project.clj
+++ b/project.clj
@@ -12,30 +12,30 @@
   :managed-dependencies
   ;; Google “Bill of Materials” (BOM) defines a combination of
   ;; dependency versions that work well with each other.
-  [[com.google.cloud/google-cloud-bom "0.185.0"
+  [[com.google.cloud/google-cloud-bom "0.192.0"
     :extension "pom"
     :scope "import"]
-   [com.google.cloud/google-cloud-shared-dependencies "3.1.2"
+   [com.google.cloud/google-cloud-shared-dependencies "3.5.0"
     :extension "pom"
     :scope "import"]]
   :dependencies
   [[org.clojure/clojure "1.11.1" :scope "provided"]
    ;; This must correspond to the version pinned in BOM files.
-   [com.google.cloud/google-cloud-core "2.9.4"]
-   [com.google.cloud/google-cloud-core-http "2.9.4"]
+   [com.google.cloud/google-cloud-core "2.13.0"]
+   [com.google.cloud/google-cloud-core-http "2.13.0"]
    ;; grpc-api is required to compile ‘clj-gcloud.common’ namespace
-   [io.grpc/grpc-api "1.52.1"]
+   [io.grpc/grpc-api "1.54.0"]
    ;; Handle version mismatches between grpc-api and other deps.
    [com.google.errorprone/error_prone_annotations "2.18.0"]]
   :profiles
   {:dev
    {:dependencies
-    [[com.google.cloud/google-cloud-bigquery "2.21.0"]
-     [com.google.cloud/google-cloud-pubsub "1.123.1"]
-     [com.google.cloud/google-cloud-datastore "2.13.3"]
-     [com.google.cloud/google-cloud-storage "2.17.2"]
-     [org.clojure/tools.namespace "1.3.0"]]
-    :source-paths   ["dev"]
+    [[com.google.cloud/google-cloud-bigquery "2.24.2"]
+     [com.google.cloud/google-cloud-pubsub "1.123.7"]
+     [com.google.cloud/google-cloud-datastore "2.14.1"]
+     [com.google.cloud/google-cloud-storage "2.20.2"]
+     [org.clojure/tools.namespace "1.4.4"]]
+    :source-paths   ["dev" "test"]
     :resource-paths ["test-resources"]
-    :test-selectors {:ci (complement :integration)}}}
-  :global-vars {*warn-on-reflection* true})
+    :test-selectors {:ci (complement :integration)}
+    :global-vars {*warn-on-reflection* true}}})

--- a/project.clj
+++ b/project.clj
@@ -23,6 +23,7 @@
    ;; This must correspond to the version pinned in BOM files.
    [com.google.cloud/google-cloud-core "2.13.0"]
    [com.google.cloud/google-cloud-core-http "2.13.0"]
+   [com.google.http-client/google-http-client-gson "1.43.1"]
    ;; grpc-api is required to compile ‘clj-gcloud.common’ namespace
    [io.grpc/grpc-api "1.54.0"]
    ;; Handle version mismatches between grpc-api and other deps.

--- a/src/clj_gcloud/common.clj
+++ b/src/clj_gcloud/common.clj
@@ -22,7 +22,7 @@
 ;; RetrySettings
 (def default-retry-settings (ServiceOptions/getDefaultRetrySettings))
 
-(defn ^RetryOption ->RetryOption
+(defn ->RetryOption ^RetryOption
   [[k v]]
   (case k
     :total-timeout (RetryOption/totalTimeout (d/->duration v))

--- a/src/clj_gcloud/dsl.clj
+++ b/src/clj_gcloud/dsl.clj
@@ -3,7 +3,7 @@
    [clojure.walk :refer [postwalk]])
   (:import
    (com.google.api.client.json JsonFactory)
-   (com.google.api.client.json.jackson2 JacksonFactory)
+   (com.google.api.client.json.gson GsonFactory)
    (com.google.common.base CaseFormat Converter)
    (java.lang.reflect Method)
    (java.util EnumSet)))
@@ -54,7 +54,7 @@
      (fn [x] (if (map? x) (into {} (map (comp xform-key xform-val) x)) x))
      m)))
 
-(def ^JsonFactory json-factory (JacksonFactory/getDefaultInstance))
+(def ^JsonFactory json-factory (GsonFactory/getDefaultInstance))
 
 (defn ^Method get-static-method
   "Returns a static method"

--- a/src/clj_gcloud/dsl.clj
+++ b/src/clj_gcloud/dsl.clj
@@ -17,14 +17,14 @@
 (def ^:private ^Converter uu->lh
   (.converterTo CaseFormat/UPPER_UNDERSCORE CaseFormat/LOWER_HYPHEN))
 
-(defn ^String kw->field-name
+(defn kw->field-name
   "Converts a keyword into a field name"
-  [kw]
+  ^String [kw]
   (->> kw name (.convert lh->lc)))
 
-(defn ^String kw->enum-str
+(defn kw->enum-str
   "Converts a keyword into a enum string"
-  [kw]
+  ^String [kw]
   (->> kw name (.convert lh->uu)))
 
 (defn enum->kw
@@ -56,9 +56,9 @@
 
 (def ^JsonFactory json-factory (GsonFactory/getDefaultInstance))
 
-(defn ^Method get-static-method
+(defn get-static-method
   "Returns a static method"
-  [^Class cls n arg-classes]
+  ^Method [^Class cls n arg-classes]
   (let [m (.getDeclaredMethod cls n (into-array Class arg-classes))]
     (.setAccessible m true)
     m))

--- a/src/clj_gcloud/dsl.clj
+++ b/src/clj_gcloud/dsl.clj
@@ -1,4 +1,6 @@
 (ns clj-gcloud.dsl
+  (:require
+   [clojure.walk :refer [postwalk]])
   (:import
    (com.google.api.client.json JsonFactory)
    (com.google.api.client.json.jackson2 JacksonFactory)
@@ -36,9 +38,9 @@
   "Creates a map of keywords -> enums"
   [c]
   (reduce
-    (fn [m e] (assoc m (enum->kw e) e))
-    {}
-    (EnumSet/allOf c)))
+   (fn [m e] (assoc m (enum->kw e) e))
+   {}
+   (EnumSet/allOf c)))
 
 (defn dsl->google-json-map
   "Recursively transforms a DSL map to conform to the Google JSON format:
@@ -48,9 +50,9 @@
   (let [xform-key (fn [[k v]] (if (keyword? k) [(kw->field-name k) v] [k v]))
         xform-val (fn [[k v]] (if (keyword? v) [k (kw->enum-str v)] [k v]))]
     ;; only apply to maps
-    (clojure.walk/postwalk
-      (fn [x] (if (map? x) (into {} (map (comp xform-key xform-val) x)) x))
-      m)))
+    (postwalk
+     (fn [x] (if (map? x) (into {} (map (comp xform-key xform-val) x)) x))
+     m)))
 
 (def ^JsonFactory json-factory (JacksonFactory/getDefaultInstance))
 


### PR DESCRIPTION
Based on dependencies listed here:
https://mvnrepository.com/artifact/com.google.cloud/libraries-bom/26.11.0

FYI, dependencies should be based off libraries-bom instead of
google-cloud-bom according to this:

https://github.com/googleapis/java-cloud-bom/tree/main/google-cloud-bom
