### PR TITLE
wip multiple types of credentials

### DIFF
--- a/src/clj_gcloud/common.clj
+++ b/src/clj_gcloud/common.clj
@@ -54,7 +54,6 @@
          (RetryOption/mergeToSettings default-retry-settings))
     (throw (ex-info (s/explain-str ::retry-settings settings) settings))))
 
-(declare mk-credentials*)
 
 (defn mk-default-credentials
   ([]
@@ -85,11 +84,6 @@
               delegates (.setDelegates delegates)))))
 
 
-;; alias for backward compatibility
-(defn mk-credentials
-  [json-path]
-  (mk-service-account-credentials {:credentials json-path}))
-
 (defmulti mk-credentials*
   (fn [{:keys [type credentials target-principal]}]
     (or
@@ -113,6 +107,12 @@
 (defmethod mk-credentials* :impersonated
   [opts]
   (mk-impersonated-credentials opts))
+
+(defn mk-credentials
+  [spec]
+  (if-not (string? spec)
+    (mk-credentials* spec)
+    (mk-service-account-credentials {:credentials spec})))
 
 
 (defn fixed-credentials


### PR DESCRIPTION
Hello,

I've added some flexibility to credentials maker while avoiding making breaking changes (at least for now).
Overall `build-service` was designed to only work with either nil (default) credentials or a service account file (without much options).

I wanted to use impersonated credentials to stop using SA files.
The library works like before : 

Application default auth : 
```
{}
;; or
{:type :application-default}
;; or
nil
````

Service account auth : 
```
{:credentials "sa.jon"}
;; or
{:type :service-account-file
 :credentials "sa.jon"}
```

Impersonated auth (https://cloud.google.com/docs/authentication/use-service-account-impersonation) : 
```
;;; SA using impersonated 
{:credentials "sa.jon"
 :target-principal "exemple@myproject.iam.gserviceaccount.com" }
;; or
{:type :impersonated
 :credentials "sa.jon"
 :target-principal "exemple@myproject.iam.gserviceaccount.com"}

;;; Application default using impersonated
{:target-principal "exemple@myproject.iam.gserviceaccount.com" }
;; or
{:type :impersonated
 :target-principal "exemple@myproject.iam.gserviceaccount.com"}
```

The `:type` explicit typing allows nested code to reuse the same options.

A better design would break `mk-credentials` but I avoided breaking changes for now ; also it would be good to add more options.
Tested with a client library.

Thanks